### PR TITLE
Ensure compilation arguments are applied

### DIFF
--- a/integration-tests/basic/src/test/java/io/quarkus/groovy/maven/it/GroovyDevModeIT.java
+++ b/integration-tests/basic/src/test/java/io/quarkus/groovy/maven/it/GroovyDevModeIT.java
@@ -85,6 +85,17 @@ class GroovyDevModeIT extends RunAndCheckMojoTestBase {
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
                 .atMost(1, TimeUnit.MINUTES).until(() -> DevModeTestUtils.getHttpResponse("/app/hello").contains(uuid));
+        await()
+                .pollDelay(1, TimeUnit.SECONDS)
+                .atMost(1, TimeUnit.MINUTES)
+                .until(() -> DevModeTestUtils.getHttpResponse("/app/hello/name").contains("someName"));
+
+        File helloService = new File(testDir, "src/main/groovy/org/acme/Hello.groovy");
+        filter(helloService, Map.of("someName", "otherName"));
+        await()
+                .pollDelay(1, TimeUnit.SECONDS)
+                .atMost(1, TimeUnit.MINUTES)
+                .until(() -> DevModeTestUtils.getHttpResponse("/app/hello/name").contains("otherName"));
     }
 
     @Test

--- a/integration-tests/basic/src/test/resources/projects/groovy-compiler-args/pom.xml
+++ b/integration-tests/basic/src/test/resources/projects/groovy-compiler-args/pom.xml
@@ -67,7 +67,7 @@
                         <compiler>
                             <name>groovy</name>
                             <args>
-                                <arg>groovy.output.debug=true</arg>
+                                <arg>groovy.parameters=true</arg>
                             </args>
                         </compiler>
                     </compilerOptions>
@@ -90,7 +90,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <debug>true</debug>
+                            <parameters>true</parameters>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-tests/basic/src/test/resources/projects/groovy-compiler-args/src/main/groovy/org/acme/Hello.groovy
+++ b/integration-tests/basic/src/test/resources/projects/groovy-compiler-args/src/main/groovy/org/acme/Hello.groovy
@@ -1,3 +1,5 @@
+package org.acme
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,27 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.acme
 
+class Hello {
 
-import jakarta.ws.rs.GET
-import jakarta.ws.rs.Path
-import jakarta.ws.rs.Produces
-import jakarta.ws.rs.core.MediaType
+    String name
 
-@Path("/app/hello")
-class HelloResource {
-
-    @GET
-    @Produces(MediaType.TEXT_PLAIN)
-    def hello4() {
-        'hello'
-    }
-
-    @Path("/name")
-    @GET
-    @Produces(MediaType.TEXT_PLAIN)
-    def name() {
-        Hello.class.getConstructors()[0].getParameters()[0].isNamePresent() ? Hello.class.getConstructors()[0].getParameters()[0].getName() : 'unknown'
+    Hello(String someName) {
+        this.name = someName
     }
 }


### PR DESCRIPTION
## Motivation

It appears that the compilation arguments are not taken into account by the `GroovyCompilationProvider` so it needs to be fixed.

## Modifications

* Modifies the code to ensure that the compilation arguments are applied
* Modifies the integration test to validate that the compilation arguments are taken into account