### PR TITLE
Fix build to release 3.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "3.0.0"
+  current-version: 3.0.0
   next-version: "999-SNAPSHOT"
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,19 +16,4 @@
     <module>resteasy</module>
     <module>spring-web</module>
   </modules>
-  <build>
-    <plugins>
-      <!--
-      This is not deployed into a Maven repository. It is merely installed into the local Maven repository
-      during a local build.
-      -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/groovy/deployment/GroovyCompilationProvider.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/groovy/deployment/GroovyCompilationProvider.java
@@ -43,6 +43,9 @@ import groovy.lang.GroovyClassLoader;
 import io.quarkus.deployment.dev.CompilationProvider;
 import io.quarkus.paths.PathCollection;
 
+/**
+ * {@code GroovyCompilationProvider} compiles sources written in Groovy that are modified in dev mode.
+ */
 public class GroovyCompilationProvider implements CompilationProvider {
 
     private static final Logger log = Logger.getLogger(GroovyCompilationProvider.class);

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/groovy/deployment/GroovyUtil.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/groovy/deployment/GroovyUtil.java
@@ -25,10 +25,22 @@ import org.jboss.jandex.Type;
 import groovy.lang.GroovyObject;
 import groovy.lang.MetaClass;
 
+/**
+ * {@code GroovyUtil} is a utility class that provides methods that are specific to the Groovy language.
+ */
 public final class GroovyUtil {
 
+    /**
+     * The {@code DotName} corresponding to the {@link GroovyObject}.
+     */
     public static final DotName DOTNAME_GROOVY_OBJECT = DotName.createSimple(GroovyObject.class.getName());
+    /**
+     * The name of the specific method allowing to get the meta class.
+     */
     public static final String METHOD_GET_META_CLASS_NAME = "getMetaClass";
+    /**
+     * The descriptor of the method {@code getMetaClass()} in asm terminology.
+     */
     public static final String METHOD_GET_META_CLASS_DESCRIPTOR = String.format("()L%s;",
             MetaClass.class.getName().replace('.', '/'));
     private static final List<String> GROOVY_PACKAGE_NAMES = List.of("org.codehaus.groovy.", "org.apache.groovy.", "groovy");
@@ -37,6 +49,7 @@ public final class GroovyUtil {
     }
 
     /**
+     * @param classInfo the class to test.
      * @return {@code true} if the given class is a Groovy object, {@code false} otherwise.
      */
     public static boolean isGroovyObject(ClassInfo classInfo) {
@@ -49,6 +62,8 @@ public final class GroovyUtil {
     }
 
     /**
+     * @param name the name of the method to test.
+     * @param descriptor the descriptor of the method to test in asm terminology.
      * @return {@code true} if the given method name and description match with the {@link GroovyObject#getMetaClass()},
      *         {@code false} otherwise.
      */
@@ -57,6 +72,7 @@ public final class GroovyUtil {
     }
 
     /**
+     * @param name the full qualified name of the class to test.
      * @return {@code true} if the given class is part of the groovy library, {@code false} otherwise.
      */
     public static boolean isGroovyClass(String name) {

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,6 @@
   <name>Quarkus Groovy - Parent</name>
   <modules>
     <module>extensions</module>
-    <module>integration-tests</module>
-    <module>examples</module>
     <module>docs</module>
   </modules>
   <properties>
@@ -197,7 +195,7 @@
       </build>
     </profile>
     <profile>
-      <id>it</id>
+      <id>it-examples</id>
       <activation>
         <property>
           <name>performRelease</name>
@@ -206,6 +204,7 @@
       </activation>
       <modules>
         <module>integration-tests</module>
+        <module>examples</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
## Motivation

The release fails and needs to be fixed

## Modifications

* Remove `integration-tests` and `examples` from the modules to always launch
* Add `examples` to the list of modules to launch only when it is not a release
* Remove the configuration of the `maven-deploy-plugin` in examples to prevent deploying the artifacts since it won't be called anymore
* Add some Javadoc 