### PR TITLE
Ref #38: Add support of extension modules

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/groovy/deployment/GroovyProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/groovy/deployment/GroovyProcessor.java
@@ -30,11 +30,16 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
 import groovy.lang.Closure;
+import io.quarkiverse.groovy.runtime.GroovyRecorder;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.IsTest;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
@@ -103,5 +108,12 @@ class GroovyProcessor {
         proxies.add(new NativeImageProxyDefinitionBuildItem(BiConsumer.class.getName()));
         proxies.add(new NativeImageProxyDefinitionBuildItem(BiPredicate.class.getName()));
         return proxies;
+    }
+
+    @BuildStep(onlyIf = IsTest.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    ServiceStartBuildItem initExtensionModules(GroovyRecorder recorder) {
+        recorder.initExtensionModules();
+        return new ServiceStartBuildItem("Groovy Extension Module Loader");
     }
 }

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/groovy/runtime/GroovyRecorder.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/groovy/runtime/GroovyRecorder.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.groovy.runtime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import groovy.lang.GroovySystem;
+import groovy.lang.MetaMethod;
+import io.quarkus.runtime.annotations.Recorder;
+import org.codehaus.groovy.reflection.CachedClass;
+import org.codehaus.groovy.reflection.ClassInfo;
+import org.codehaus.groovy.runtime.m12n.ExtensionModuleScanner;
+import org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl;
+import org.codehaus.groovy.util.URLStreams;
+import org.jboss.logging.Logger;
+
+@Recorder
+public class GroovyRecorder {
+
+    private static final Logger LOG = Logger.getLogger(GroovyRecorder.class);
+
+    public void initExtensionModules() {
+        if (GroovySystem.getMetaClassRegistry() instanceof MetaClassRegistryImpl) {
+            scanModulesFrom(ExtensionModuleScanner.MODULE_META_INF_FILE);
+            scanModulesFrom(ExtensionModuleScanner.LEGACY_MODULE_META_INF_FILE);
+        }
+    }
+
+    private static void scanModulesFrom(String moduleMetaInfFile) {
+        try {
+            Enumeration<URL> resources = Thread.currentThread().getContextClassLoader().getResources(moduleMetaInfFile);
+            while (resources.hasMoreElements()) {
+                URL url = resources.nextElement();
+                scanExtensionModuleFromMetaInf(url);
+            }
+        } catch (IOException e) {
+            LOG.warnf("An error occurred while scanning the extension modules '%s': %s", moduleMetaInfFile, e.getMessage());
+        }
+    }
+
+    private static void scanExtensionModuleFromMetaInf(final URL metadata) {
+        try (InputStream inStream = URLStreams.openUncachedStream(metadata)) {
+            Properties properties = new Properties();
+            properties.load(inStream);
+            registerExtensionModuleFromProperties(properties);
+        } catch (IOException e) {
+            LOG.warnf("An error occurred while registering the extension module '%s': %s", metadata, e.getMessage());
+        }
+    }
+
+    private static void registerExtensionModuleFromProperties(Properties properties) {
+        Map<CachedClass, List<MetaMethod>> metaMethods = new HashMap<>();
+        MetaClassRegistryImpl registry = (MetaClassRegistryImpl) GroovySystem.getMetaClassRegistry();
+        registry.registerExtensionModuleFromProperties(properties, Thread.currentThread().getContextClassLoader(), metaMethods);
+        for (Map.Entry<CachedClass, List<MetaMethod>> entry : metaMethods.entrySet()) {
+            CachedClass c = entry.getKey();
+            Set<CachedClass> classesToBeUpdated = new HashSet<>();
+            classesToBeUpdated.add(c);
+            ClassInfo.onAllClassInfo(
+                    info -> {
+                        if (c.getTheClass().isAssignableFrom(info.getCachedClass().getTheClass())) {
+                            classesToBeUpdated.add(info.getCachedClass());
+                        }
+                    });
+            classesToBeUpdated.forEach(cc -> cc.addNewMopMethods(entry.getValue()));
+        }
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -12,6 +12,7 @@
   <modules>
     <module>basic</module>
     <module>shared-library</module>
+    <module>resteasy</module>
     <module>resteasy-reactive</module>
     <module>hibernate-orm-panache</module>
     <module>hibernate-reactive-panache</module>

--- a/integration-tests/resteasy/pom.xml
+++ b/integration-tests/resteasy/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.groovy</groupId>
+        <artifactId>quarkus-groovy-integration-tests</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-groovy-integration-tests-resteasy</artifactId>
+    <name>Quarkus Groovy - Integration Tests - RESTEasy Groovy tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.groovy</groupId>
+            <artifactId>quarkus-groovy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.groovy</groupId>
+            <artifactId>quarkus-groovy-integration-test-shared-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/groovy</sourceDirectory>
+        <testSourceDirectory>src/test/groovy</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>${groovy-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compileTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/resteasy/src/main/groovy/io/quarkiverse/groovy/it/resteasy/GroovyExtensionModuleResource.groovy
+++ b/integration-tests/resteasy/src/main/groovy/io/quarkiverse/groovy/it/resteasy/GroovyExtensionModuleResource.groovy
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.groovy.it.resteasy
+
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+
+@Path("/extension")
+class GroovyExtensionModuleResource {
+
+    @GET
+    @Path("/static")
+    @Produces(MediaType.TEXT_PLAIN)
+    def staticExtension() {
+        String.greeting()
+    }
+
+    @GET
+    @Path("/instance")
+    @Produces(MediaType.TEXT_PLAIN)
+    def instanceExtension() {
+        int i=0
+        5.maxRetries {
+            i++
+        }
+        assert i == 1
+        i=0
+        try {
+            5.maxRetries {
+                i++
+                throw new RuntimeException("oops")
+            }
+        } catch (RuntimeException e) {
+            assert i == 5
+        }
+        "Tried $i times"
+    }
+}

--- a/integration-tests/resteasy/src/test/groovy/io/quarkiverse/groovy/it/resteasy/GroovyExtensionModuleResourceTest.groovy
+++ b/integration-tests/resteasy/src/test/groovy/io/quarkiverse/groovy/it/resteasy/GroovyExtensionModuleResourceTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkiverse.groovy.it.resteasy
+
+import io.quarkus.test.junit.QuarkusTest
+import org.junit.jupiter.api.Test
+
+import static io.restassured.RestAssured.given
+import static org.hamcrest.CoreMatchers.is
+
+@QuarkusTest
+class GroovyExtensionModuleResourceTest {
+
+    @Test
+    void testStaticExtension() {
+        given()
+                .when()
+                .get("/extension/static")
+                .then()
+                .statusCode(200)
+                .body(is("Hello, world!"))
+    }
+
+    @Test
+    void testInstanceExtension() {
+        given()
+                .when()
+                .get("/extension/instance")
+                .then()
+                .statusCode(200)
+                .body(is("Tried 5 times"))
+    }
+}

--- a/integration-tests/shared-library/src/main/groovy/io/quarkiverse/groovy/it/shared/extensions/MaxRetriesExtension.groovy
+++ b/integration-tests/shared-library/src/main/groovy/io/quarkiverse/groovy/it/shared/extensions/MaxRetriesExtension.groovy
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.groovy.it.shared.extensions
+
+class MaxRetriesExtension {
+    static void maxRetries(Integer self, Closure code) {
+        assert self >= 0
+        int retries = self
+        Throwable e = null
+        while (retries > 0) {
+            try {
+                code.call()
+                break
+            } catch (Throwable err) {
+                e = err
+                retries--
+            }
+        }
+        if (retries == 0 && e) {
+            throw e
+        }
+    }
+}

--- a/integration-tests/shared-library/src/main/groovy/io/quarkiverse/groovy/it/shared/extensions/StaticStringExtension.groovy
+++ b/integration-tests/shared-library/src/main/groovy/io/quarkiverse/groovy/it/shared/extensions/StaticStringExtension.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.groovy.it.shared.extensions
+
+class StaticStringExtension {
+    static String greeting(String self) {
+        'Hello, world!'
+    }
+}

--- a/integration-tests/shared-library/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/integration-tests/shared-library/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+moduleName=quarkus-groovy-integration-test-shared-library
+moduleVersion=1.0.0
+extensionClasses=io.quarkiverse.groovy.it.shared.extensions.MaxRetriesExtension
+staticExtensionClasses=io.quarkiverse.groovy.it.shared.extensions.StaticStringExtension


### PR DESCRIPTION
fixes #38 

## Motivation

Due to the ClassLoader hierarchy in Quarkus, we can face situations where the extension modules are not loaded properly.

## Modifications

* Add a recorder to load the extension modules in test mode only
* Add a new integration test to validate the behavior