### PR TITLE
Ref #42 - Avoid raising exceptions on module version conflicts

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: 3.2.0
+  current-version: 3.2.1
   next-version: "999-SNAPSHOT"
 

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/groovy/runtime/GroovyRecorder.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/groovy/runtime/GroovyRecorder.java
@@ -16,7 +16,6 @@
  */
 package io.quarkiverse.groovy.runtime;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
@@ -57,7 +56,7 @@ public class GroovyRecorder {
                 URL url = resources.nextElement();
                 scanExtensionModuleFromMetaInf(url);
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOG.warnf("An error occurred while scanning the extension modules '%s': %s", moduleMetaInfFile, e.getMessage());
         }
     }
@@ -67,7 +66,7 @@ public class GroovyRecorder {
             Properties properties = new Properties();
             properties.load(inStream);
             registerExtensionModuleFromProperties(properties);
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOG.warnf("An error occurred while registering the extension module '%s': %s", metadata, e.getMessage());
         }
     }


### PR DESCRIPTION
fixes #42 

## Motivation

In case of a module version conflict, a `GroovyRuntimeException` is raised which prevents Quarkus to start while a simple warning is more appropriate in this case.

## Modification:

* Catch all kinds of exceptions while loading the extension modules