### PR TITLE
Upgrade Quarkus to the latest snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/github/license/quarkiverse/quarkus-groovy)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Central](https://img.shields.io/maven-central/v/io.quarkiverse.groovy/quarkus-groovy?color=green)](https://search.maven.org/search?q=g:io.quarkiverse.groovy%20AND%20a:quarkus-groovy)
 
-Quarkus Groovy is a Quarkus extension allowing to write Quarkus 3.2 applications in Groovy 4.0. 
+Quarkus Groovy is a Quarkus extension allowing to write Quarkus 3.3 applications in Groovy 4.0.
 
 With Maven, add the following dependency to your `pom.xml` to get started:
 

--- a/examples/gradle-resteasy/gradle.properties
+++ b/examples/gradle-resteasy/gradle.properties
@@ -1,5 +1,5 @@
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformGroupId=io.quarkus
-quarkusPluginVersion=3.2.2.Final
-quarkusPlatformVersion=3.2.2.Final
+quarkusPluginVersion=999-SNAPSHOT
+quarkusPlatformVersion=999-SNAPSHOT
 version=999-SNAPSHOT

--- a/extensions/core/runtime/pom.xml
+++ b/extensions/core/runtime/pom.xml
@@ -22,6 +22,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.graalvm.sdk</groupId>
+      <artifactId>graal-sdk</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.2.2.Final</quarkus.version>
+    <quarkus.version>999-SNAPSHOT</quarkus.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>${quarkus.version}</quarkus.platform.version>


### PR DESCRIPTION
## Motivation

To ensure that the extension is compatible with the latest snapshot of Quakus, the version of Quarkus needs to be set to `999-SNAPSHOT`.

## Modifications:

* Sets the version of Quarkus to `999-SNAPSHOT`
* Adapts the code and the doc to the latest snapshot