### PR TITLE
Ref #129: Force the version of the jandex plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <quarkus.platform.version>${quarkus.version}</quarkus.platform.version>
     <groovy.version>4.0.21</groovy.version>
     <groovy-maven-plugin.version>3.0.2</groovy-maven-plugin.version>
+    <jandex-maven-plugin.version>3.1.7</jandex-maven-plugin.version>
     <hibernate-orm.version>6.4.0.Final</hibernate-orm.version>
     <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
     <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
@@ -124,6 +125,11 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>${exec-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>io.smallrye</groupId>
+          <artifactId>jandex-maven-plugin</artifactId>
+          <version>${jandex-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
fixes #129 

## Motivation

The build constantly fails due to an incompatible version of the index

## Modifications:

* Force the version of the Jandex maven plugin to ensure that it is compatible with what Quarkus supports 