### PR TITLE
Add log4j to the rest integration tests

### DIFF
--- a/integration-tests/rest/pom.xml
+++ b/integration-tests/rest/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Motivation

[The nightly build fails](https://productionresultssa0.blob.core.windows.net/actions-results/237cd981-4af6-415b-b7a9-c4c29821aa4e/workflow-job-run-ca395085-040a-526b-2ce8-bdc85f692774/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-01-20T07%3A41%3A33Z&sig=dIXlToAIj8wQapZk%2FOMRScVHwWZN4Qwp2ocM2i5XpkU%3D&ske=2025-01-20T16%3A20%3A08Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-01-20T04%3A20%3A08Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-11-04&sp=r&spr=https&sr=b&st=2025-01-20T07%3A31%3A28Z&sv=2024-11-04) due to a missing dependency in the integration tests of rest 

## Modifications:

* Add log4j with a test scope to the integration tests of rest