### PR TITLE
Use the new InjectMock class

### DIFF
--- a/integration-tests/hibernate-reactive-panache/src/test/groovy/io/quarkiverse/groovy/it/panache/reactive/PanacheMockingTest.groovy
+++ b/integration-tests/hibernate-reactive-panache/src/test/groovy/io/quarkiverse/groovy/it/panache/reactive/PanacheMockingTest.groovy
@@ -17,6 +17,7 @@
 package io.quarkiverse.groovy.it.panache.reactive
 
 import groovy.transform.CompileStatic
+import io.quarkus.test.InjectMock
 
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNull
@@ -34,7 +35,6 @@ import io.quarkiverse.groovy.hibernate.reactive.panache.Panache
 import io.quarkiverse.groovy.hibernate.reactive.panache.PanacheRepositoryBase
 import io.quarkus.panache.mock.PanacheMock
 import io.quarkus.test.junit.QuarkusTest
-import io.quarkus.test.junit.mockito.InjectMock
 import io.quarkus.test.vertx.RunOnVertxContext
 import io.quarkus.test.vertx.UniAsserter
 import io.smallrye.mutiny.Uni


### PR DESCRIPTION
## Motivation

`io.quarkus.test.junit.mockito.InjectMock` is deprecated and has been removed in last Quarkus version

## Modification

*  Use the new InjectMock class which is `io.quarkus.test.InjectMock`