### PR TITLE
Specify argument types to avoid MultipleCompilationErrorsException

### DIFF
--- a/integration-tests/hibernate-orm-panache/src/test/groovy/io/quarkiverse/groovy/it/panache/PanacheMockingTest.groovy
+++ b/integration-tests/hibernate-orm-panache/src/test/groovy/io/quarkiverse/groovy/it/panache/PanacheMockingTest.groovy
@@ -46,7 +46,7 @@ class PanacheMockingTest {
     void setup() {
         Query mockQuery = Mockito.mock(Query.class)
         Mockito.doNothing().when(session).persist(Mockito.any())
-        Mockito.when(session.createSelectionQuery(Mockito.anyString(), Mockito.any())).thenReturn(mockQuery)
+        Mockito.when(session.createSelectionQuery(Mockito.anyString(), Mockito.any(Class.class))).thenReturn(mockQuery)
         Mockito.when(mockQuery.getSingleResult()).thenReturn(0l)
     }
 


### PR DESCRIPTION
## Motivation

The nightly build fails due to the following exception:
```
Caused by: org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
integration-tests/hibernate-orm-panache/src/test/groovy/io/quarkiverse/groovy/it/panache/PanacheMockingTest.groovy: 49: [Static type checking] - Reference to method is ambiguous. Cannot choose between [org.hibernate.query.SelectionQuery<R> org.hibernate.query.QueryProducer#createSelectionQuery(java.lang.String, java.lang.Class<R>), org.hibernate.query.SelectionQuery<R> org.hibernate.query.QueryProducer#createSelectionQuery(java.lang.String, jakarta.persistence.EntityGraph<R>)]
@ line 49, column 22.
           Mockito.when(session.createSelectionQuery(Mockito.anyString(), Mockito.any())).thenReturn(mockQuery)
```

## Modifications:

* Provide the argument type